### PR TITLE
Ensure that produced TypeScript is compilable, and handle unusual keys

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/__tests__/out/*.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 /lib
+/src/__tests__/out

--- a/package-lock.json
+++ b/package-lock.json
@@ -192,9 +192,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -425,6 +425,23 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -470,6 +487,28 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
       "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.0.tgz",
+      "integrity": "sha512-WE4IOAC6r/yBZss1oQGM5zs2D7RuKR6Q+w+X2SouPofnWn+LbCqClRyhO3ZE7Ix8nmFgo/oVuuE01cJT2XB13A==",
+      "dev": true
+    },
+    "@types/rimraf": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -547,9 +586,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-globals": {
@@ -563,9 +602,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -837,6 +876,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1091,13 +1140,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true,
-      "optional": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1850,6 +1892,13 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -1949,14 +1998,15 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+      "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
       "dev": true,
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -2004,7 +2054,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2034,7 +2084,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2061,12 +2111,12 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -2092,7 +2142,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2121,7 +2171,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2140,7 +2190,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2176,13 +2226,13 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.5",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2192,42 +2242,42 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
+          "version": "0.5.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2241,11 +2291,11 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
-          "version": "4.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2255,19 +2305,29 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npmlog": {
@@ -2332,7 +2392,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2347,18 +2407,10 @@
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
+          "version": "2.3.7",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2373,7 +2425,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2400,7 +2452,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2453,18 +2505,18 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -2489,7 +2541,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2585,18 +2637,6 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2680,6 +2720,12 @@
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -3073,12 +3119,12 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0"
       }
     },
     "jest": {
@@ -3556,9 +3602,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         }
       }
@@ -3609,9 +3655,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -3629,9 +3675,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "kleur": {
@@ -3828,12 +3874,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -3856,12 +3896,20 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "ms": {
@@ -3906,12 +3954,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nice-try": {
@@ -4090,24 +4132,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -4640,9 +4664,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -5334,21 +5358,10 @@
       }
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
-    },
-    "uglify-js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
-      "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "2.20.0",
-        "source-map": "~0.6.1"
-      }
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.0.18",
+    "@types/node": "^13.13.0",
+    "@types/rimraf": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^2.3.3",
     "@typescript-eslint/parser": "^2.3.3",
     "eslint": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "type": "git",
     "url": "git+https://github.com/pabra/json-literal-typer.git"
   },
+  "contributors": [
+    "Michael Scott-Nelson <mscottnelson@gmail.com> (https://github.com/mscottnelson)"
+  ],
   "bugs": {
     "url": "https://github.com/pabra/json-literal-typer/issues"
   },

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -52,6 +52,78 @@ const testData = [
     tsOut: 'interface Root {\n  a: 1;\n}',
   },
   {
+    name: 'object with spaces in key',
+    in: { "With some spaces": 1 },
+    jsonOut: {
+      type: 'object',
+      path: '$',
+      keys: {
+        "With some spaces": {
+          values: [{ type: 'number', path: `$['With some spaces']{number}`, values: [1] }],
+        },
+      },
+    },
+    tsOut: 'interface Root {\n  "With some spaces": 1;\n}',
+  },
+  {
+    name: 'object starting with number starting key',
+    in: { "2numberStart": 1 },
+    jsonOut: {
+      type: 'object',
+      path: '$',
+      keys: {
+        "2numberStart": {
+          values: [{ type: 'number', path: `$['2numberStart']{number}`, values: [1]}],
+        },
+      },
+    },
+    tsOut: 'interface Root {\n  "2numberStart": 1;\n}',
+  },
+  {
+    name: 'object with unusual characters in key',
+    in: { "*~@#$%^&*()_+=><?/": 1 },
+    jsonOut: {
+      type: 'object',
+      path: '$',
+      keys: {
+        "*~@#$%^&*()_+=><?/": {
+          values: [{ type: 'number', path: `$['*~@#$%^&*()_+=><?/']{number}`, values: [1]}],
+        },
+      },
+    },
+    tsOut: 'interface Root {\n  "*~@#$%^&*()_+=><?/": 1;\n}',
+  },
+  {
+    name: 'object with difficult to handle but valid characters in keys',
+    in: { "\\\"": 1 },
+    jsonOut: {
+      type: 'object',
+      path: '$',
+      keys: {
+        "\\\"": {
+          // eslint-disable-next-line no-useless-escape
+          values: [{ type: 'number', path: `$['\\\"']{number}`, values: [1]}],
+        },
+      },
+    },
+    // eslint-disable-next-line no-useless-escape
+    tsOut: 'interface Root {\n  "\\\"": 1;\n}',
+  },
+  {
+    name: 'object with emojis in keys',
+    in: { "🥰👍": 1 },
+    jsonOut: {
+      type: 'object',
+      path: '$',
+      keys: {
+        "🥰👍": {
+          values: [{ type: 'number', path: `$['🥰👍']{number}`, values: [1]}],
+        },
+      },
+    },
+    tsOut: 'interface Root {\n  "🥰👍": 1;\n}',
+  },
+  {
     name: 'object with keys of different and optional types',
     in: {
       data: [

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import analyze, { jsonify, typify } from '../';
-import * as ts from 'typescript';
+import ts from 'typescript';
 import { writeFile, PathLike, exists, mkdir } from 'fs';
 import rimraf from 'rimraf';
 import { promisify, inspect } from 'util';

--- a/src/jsonify.ts
+++ b/src/jsonify.ts
@@ -3,7 +3,7 @@ import { PrimitiveObject, ArrayObject, ObjectObject } from './analyze';
 interface ArrayJson {
   type: 'array';
   path: string;
-  values: {};
+  values: Iterable<{}>;
 }
 
 interface ObjectJson {

--- a/src/typify.ts
+++ b/src/typify.ts
@@ -70,6 +70,7 @@ const invalidIdentifiers = new Set<string>([
 function uniqueIdentifier(
   thing: PrimitiveObject | ArrayObject | ObjectObject,
   identifiers: Set<string>,
+  typePrefix?: string,
 ) {
   let name: string;
   if (typeof thing.name === 'string') {
@@ -78,6 +79,10 @@ function uniqueIdentifier(
     name = thing.parent.name;
   } else {
     name = 'list';
+  }
+
+  if (typePrefix) {
+    name = typePrefix + name;
   }
 
   name = name.replace(/\W+/gi, 'X');
@@ -210,7 +215,7 @@ function typifyNull({ thing, nodes, ids, config }: TypifyNullArgs) {
     return { count: 1, value };
   }
 
-  const identifier = uniqueIdentifier(thing, ids);
+  const identifier = uniqueIdentifier(thing, ids, config.typePrefix);
   const stringified = `type ${identifier} = ${value};`;
   const node: Node = {
     name: thing.name,
@@ -238,7 +243,7 @@ function typifyString({ thing, nodes, ids, config }: TypifyStringArgs) {
     return { count: thing.values.size, value };
   }
 
-  const identifier = uniqueIdentifier(thing, ids);
+  const identifier = uniqueIdentifier(thing, ids, config.typePrefix);
   const stringified = `type ${identifier} = ${value};`;
   const node: Node = {
     name: thing.name,
@@ -265,7 +270,7 @@ function typifyNumber({ thing, nodes, ids, config }: TypifyNumberArgs) {
     return { count: thing.values.size, value };
   }
 
-  const identifier = uniqueIdentifier(thing, ids);
+  const identifier = uniqueIdentifier(thing, ids, config.typePrefix);
   const stringified = `type ${identifier} = ${value};`;
   const node: Node = {
     name: thing.name,
@@ -292,7 +297,7 @@ function typifyBoolean({ thing, nodes, ids, config }: TypifyBooleanArgs) {
     return { count: thing.values.size, value };
   }
 
-  const identifier = uniqueIdentifier(thing, ids);
+  const identifier = uniqueIdentifier(thing, ids, config.typePrefix);
   const stringified = `type ${identifier} = ${value};`;
   const node: Node = {
     name: thing.name,
@@ -326,7 +331,7 @@ function typifyArray({ thing, nodes, ids, config }: TypifyArrayArgs) {
     return { count: 1, value };
   }
 
-  const identifier = uniqueIdentifier(thing, ids);
+  const identifier = uniqueIdentifier(thing, ids, config.typePrefix);
   const stringified = `type ${identifier} = ${value};`;
   const node: Node = {
     name: thing.name,
@@ -377,7 +382,7 @@ function typifyObject({ thing, nodes, ids, config }: TypifyObjecArgs) {
     return { count: 1, value };
   }
 
-  const identifier = uniqueIdentifier(thing, ids);
+  const identifier = uniqueIdentifier(thing, ids, config.typePrefix);
   const stringified = `interface ${identifier} ${value}`;
   const node: Node = {
     name: thing.name,
@@ -423,6 +428,7 @@ function typifyThing({
 interface Config {
   maxLiteralPerType?: number;
   byPath: Record<string, { forceType?: boolean; baseType?: boolean }>;
+  typePrefix?: string;
 }
 const baseConfig: Config = {
   maxLiteralPerType: 10,

--- a/src/typify.ts
+++ b/src/typify.ts
@@ -80,6 +80,12 @@ function uniqueIdentifier(
     name = 'list';
   }
 
+  name = name.replace(/\W+/gi, 'X');
+
+  if(/^\d/.test(name)){
+    name = `N${name}`
+  }
+
   const localInvalidIdentifiers = new Set(invalidIdentifiers);
   if (thing.parent !== null) {
     localInvalidIdentifiers.add('Root');
@@ -426,11 +432,8 @@ const forcedConfig: Config = { byPath: { $: { forceType: true } } };
 
 function typify(
   result: PrimitiveObject | ArrayObject | ObjectObject,
-  conf?: Config,
+  conf: Config = { byPath: {} },
 ) {
-  if (!conf) {
-    conf = { byPath: {} };
-  }
   const nodes: Nodes = { byPath: {}, byOrder: [] };
   const identifiers = new Set<string>();
   const config: Config = { ...baseConfig, ...conf, ...forcedConfig } as const;

--- a/src/typify.ts
+++ b/src/typify.ts
@@ -334,6 +334,17 @@ function typifyArray({ thing, nodes, ids, config }: TypifyArrayArgs) {
   return { count: 1, value: identifier };
 }
 
+function formatKeyname(keyname: string){
+  const obj: any = {};
+  Object.defineProperty(obj, keyname, { value: 1, enumerable: true });
+  try {
+    eval(`obj.${keyname}`);
+  } catch(err) {
+    return `"${keyname}"`;
+  }
+  return keyname;
+}
+
 function typifyObject({ thing, nodes, ids, config }: TypifyObjecArgs) {
   const forceType =
     (config.byPath[thing.path] || {}).forceType === false ? false : true;
@@ -346,8 +357,9 @@ function typifyObject({ thing, nodes, ids, config }: TypifyObjecArgs) {
         ids,
         config,
       });
-
-      return `${keyname}${thing.keys[keyname].optional ? '?' : ''}: ${
+      
+      const formattedKey = formatKeyname(keyname);
+      return `${formattedKey}${thing.keys[keyname].optional ? '?' : ''}: ${
         values.value
       };`;
     })

--- a/src/typify.ts
+++ b/src/typify.ts
@@ -82,8 +82,8 @@ function uniqueIdentifier(
 
   name = name.replace(/\W+/gi, 'X');
 
-  if(/^\d/.test(name)){
-    name = `N${name}`
+  if (/^\d/.test(name)) {
+    name = `N${name}`;
   }
 
   const localInvalidIdentifiers = new Set(invalidIdentifiers);
@@ -340,12 +340,12 @@ function typifyArray({ thing, nodes, ids, config }: TypifyArrayArgs) {
   return { count: 1, value: identifier };
 }
 
-function formatKeyname(keyname: string){
+function formatKeyname(keyname: string) {
   const obj: any = {};
   Object.defineProperty(obj, keyname, { value: 1, enumerable: true });
   try {
     eval(`obj.${keyname}`);
-  } catch(err) {
+  } catch (err) {
     return `"${keyname}"`;
   }
   return keyname;
@@ -363,7 +363,7 @@ function typifyObject({ thing, nodes, ids, config }: TypifyObjecArgs) {
         ids,
         config,
       });
-      
+
       const formattedKey = formatKeyname(keyname);
       return `${formattedKey}${thing.keys[keyname].optional ? '?' : ''}: ${
         values.value


### PR DESCRIPTION
I was delighted to find this lib. Thanks for putting it together! I am in a situation that includes unusual JSON that I would still like strongly typed `const` types for throughout (ie a massive configuration file).

This PR handles those situations by:
- if a JSON key begins with a number, its interface name is prepended with "N"
- if a JSON key contains non-word characters (not a-zA-Z0-9), replace those characters with "X" in the interface name
- for values that remain object keys (not interface names), surround the key names with quotes when necessary
- ensure that typescript produced in tests is actually compilable by attempting to compile it and failing if it does not compile
- allow interface name prefix value as configuration option as a "en masse" hack to avoid situations where there are namespace collisions